### PR TITLE
fix: migrate scan.py from bluepy to bleak

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    strategy:
+      matrix:
+        language: [python]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/require-issue.yml
+++ b/.github/workflows/require-issue.yml
@@ -1,0 +1,21 @@
+name: Require Linked Issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-issue-link:
+    name: Check for linked issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body for issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if echo "$PR_BODY" | grep -iqE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+'; then
+            echo "Found linked issue reference"
+          else
+            echo "::error::PR body must link an issue using 'Fixes #N', 'Closes #N', or 'Resolves #N'"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbus-btbattery
 
-This is a driver for VenusOS devices (as of yet only tested on
+This is a driver for VenusOS devices (originally tested on
 Raspberry Pi running the VenusOS v2.92 image).
 
 The driver will communicate with a Battery Management System (BMS)
@@ -10,14 +10,17 @@ via Bluetooth and publish this data to the VenusOS system.
 [bleak](https://github.com/hbldh/bleak) (pure Python, no
 compilation needed).
 
-This project is derived from Louis Van Der Walt's dbus-serialbattery
-found here:
-<https://github.com/Louisvdw/dbus-serialbattery>
+This project is a fork of Brad Cagle's
+[dbus-btbattery](https://github.com/bradcagle/dbus-btbattery),
+which is derived from Louis Van Der Walt's
+[dbus-serialbattery](https://github.com/Louisvdw/dbus-serialbattery).
+This fork adds parallel battery support, migrates from bluepy to
+bleak, and targets Python 3 / VenusOS compatibility.
 
 ## Instructions
 
-To get started you need a VenusOS device. I've only tried on
-Raspberry Pi, you can follow my instructions here:
+To get started you need a VenusOS device. You can follow
+Brad's instructions here:
 <https://www.youtube.com/watch?v=yvGdNOZQ0Rw>
 to set one up.
 
@@ -38,7 +41,7 @@ You need to setup some dependencies on your VenusOS first
 
 ```sh
 cd /opt/victronenergy/
-git clone https://github.com/bradcagle/dbus-btbattery.git
+git clone https://github.com/pace551/dbus-btbattery.git
 ```
 
 Then from the `dbus-btbattery` directory you can run:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Raspberry Pi running the VenusOS v2.92 image).
 The driver will communicate with a Battery Management System (BMS)
 via Bluetooth and publish this data to the VenusOS system.
 
+**Requires Python 3.** BLE communication uses
+[bleak](https://github.com/hbldh/bleak) (pure Python, no
+compilation needed).
+
 This project is derived from Louis Van Der Walt's dbus-serialbattery
 found here:
 <https://github.com/Louisvdw/dbus-serialbattery>
@@ -26,16 +30,11 @@ You need to setup some dependencies on your VenusOS first
    `opkg update`
 4. Install pip:
    `opkg install python3-pip`
-5. Install build essentials as bluepy has some C code that needs
-   to be compiled:
-   `opkg install packagegroup-core-buildessential`
-6. Install glib-dev required by bluepy:
-   `opkg install libglib-2.0-dev`
-7. Install bluepy:
-   `pip3 install bluepy`
-8. Install git:
+5. Install bleak (pure Python BLE library):
+   `pip3 install bleak`
+6. Install git:
    `opkg install git`
-9. Clone dbus-btbattery repo:
+7. Clone dbus-btbattery repo:
 
 ```sh
 cd /opt/victronenergy/

--- a/README.md
+++ b/README.md
@@ -1,66 +1,131 @@
 # dbus-btbattery
-This is a driver for VenusOS devices (As of yet only tested on Raspberry Pi running the VenusOS v2.92 image). 
 
-The driver will communicate with a Battery Management System (BMS) via Bluetooth and publish this data to the VenusOS system. 
+This is a driver for VenusOS devices (as of yet only tested on
+Raspberry Pi running the VenusOS v2.92 image).
 
-This project is derived from Louis Van Der Walt's dbus-serialbattery found here: https://github.com/Louisvdw/dbus-serialbattery
+The driver will communicate with a Battery Management System (BMS)
+via Bluetooth and publish this data to the VenusOS system.
 
-### Instructions
-To get started you need a VenusOS device. I've only tried on Raspberry Pi, you can follow my instructions here: https://www.youtube.com/watch?v=yvGdNOZQ0Rw
+This project is derived from Louis Van Der Walt's dbus-serialbattery
+found here:
+<https://github.com/Louisvdw/dbus-serialbattery>
+
+## Instructions
+
+To get started you need a VenusOS device. I've only tried on
+Raspberry Pi, you can follow my instructions here:
+<https://www.youtube.com/watch?v=yvGdNOZQ0Rw>
 to set one up.
 
+You need to setup some dependencies on your VenusOS first
 
-You need to setup some depenacies on your VenusOS first
+1. SSH to IP assigned to venus device
+2. Resize/Expand file system:
+   `/opt/victronenergy/swupdate-scripts/resize2fs.sh`
+3. Update opkg:
+   `opkg update`
+4. Install pip:
+   `opkg install python3-pip`
+5. Install build essentials as bluepy has some C code that needs
+   to be compiled:
+   `opkg install packagegroup-core-buildessential`
+6. Install glib-dev required by bluepy:
+   `opkg install libglib-2.0-dev`
+7. Install bluepy:
+   `pip3 install bluepy`
+8. Install git:
+   `opkg install git`
+9. Clone dbus-btbattery repo:
 
-1) SSH to IP assigned to venus device<br/>
-
-2) Resize/Expand file system<br/>
-/opt/victronenergy/swupdate-scripts/resize2fs.sh
-
-3) Update opkg<br/>
-opkg update
-
-4) Install pip<br/>
-opkg install python3-pip
-
-5) Install build essentials as bluepy has some C code that needs to be compiled<br/>
-opkg install packagegroup-core-buildessential
-
-6) Install glib-dev required by bluepy<br/>
-opkg install libglib-2.0-dev
-
-7) Install bluepi<br/>
-pip3 install bluepy
-
-8) Install git<br/>
-opkg install git
-
-9) Clone dbus-btbattery repo<br/>
-cd /opt/victronenergy/<br/>
+```sh
+cd /opt/victronenergy/
 git clone https://github.com/bradcagle/dbus-btbattery.git
+```
 
-cd dbus-btbattery<br/>
-You can now run ./dbus-btbattery.py 70:3e:97:08:00:62<br/>
-replace 70:3e:97:08:00:62 with the Bluetooth address of your BMS/Battery<br/>
+Then from the `dbus-btbattery` directory you can run:
 
-You can run ./scan.py to find Bluetooth devices around you<br/>
+```sh
+./dbus-btbattery.py 70:3e:97:08:00:62
+```
 
-### To make dbus-btbattery startup automatically
-nano service/run<br/> 
-and replace 70:3e:97:08:00:62 with the Bluetooth address of your BMS/Battery<br/>
-Save with "Ctrl O"<br/>
-run ./installservice.sh<br/>
-reboot<br/>
+Replace `70:3e:97:08:00:62` with the Bluetooth address of your
+BMS/Battery.
 
+You can run `./scan.py` to find Bluetooth devices around you.
 
-### New Virtual Battery Feature [Experimental]
-You can now add up to 4 bt battery addresses to the command line. It will connect to all batteries, and create a<br/>
-single virtual battery. NOTE for now this only works with batteries in series, I will add parallel support soon.<br/>
+## To make dbus-btbattery startup automatically
 
-Example of my two 12v batteries in series, the display shows a 24v battery<br/> 
-./dbus-btbattery.py 70:3e:97:08:00:62 a4:c1:37:40:89:5e<br/>
+1. Edit `service/run` and replace `70:3e:97:08:00:62` with the
+   Bluetooth address of your BMS/Battery
+2. Save with "Ctrl O"
+3. Run `./installservice.sh`
+4. Reboot
 
+## Multi-Battery Modes
 
-NOTES: This driver is far from complete, so some things will probably be broken. Also only JBD BMS is currenly supported 
+dbus-btbattery supports monitoring multiple batteries in
+**series** or **parallel** configurations.
 
+### Series Mode
 
+Combines multiple batteries into a single virtual battery
+(e.g., two 12V batteries showing as one 24V battery). Voltages
+are summed, current is shared, and cell counts are combined.
+
+```sh
+./dbus-btbattery.py --series 70:3e:97:08:00:62 a4:c1:37:40:89:5e
+```
+
+### Parallel Mode
+
+Registers each battery as its own D-Bus service **plus** an
+aggregate service, so you can monitor per-battery SOC alongside
+a combined system view. The aggregate averages voltage and SOC,
+sums current and capacity, uses min cell voltages, max
+temperatures, AND-gates FET states, and applies worst-case
+protection status.
+
+```sh
+./dbus-btbattery.py --parallel 70:3e:97:08:00:62 a4:c1:37:40:89:5e
+```
+
+For backwards compatibility, passing multiple addresses without
+a flag defaults to series mode.
+
+## Configurable Timing
+
+Polling intervals can be set via CLI flags or `config.ini`:
+
+<!-- markdownlint-disable MD013 -->
+
+| Setting              | CLI Flag               | Default | Description                          |
+| -------------------- | ---------------------- | ------- | ------------------------------------ |
+| `BT_POLL_INTERVAL`   | `--bt-poll-interval`   | 30      | BLE poll interval (seconds)          |
+| `BT_WATCHDOG_TIMER`  | `--bt-watchdog-timer`  | 300     | BT watchdog timer (seconds, 0=off)   |
+| `DBUS_POLL_INTERVAL` | `--dbus-poll-interval` | 5000    | D-Bus publish interval (milliseconds)|
+
+<!-- markdownlint-enable MD013 -->
+
+CLI flags override `config.ini` values. See `default_config.ini`
+for all available settings including connection mode and BT
+addresses.
+
+## Configuration via config.ini
+
+You can also configure multi-battery mode and addresses in
+`config.ini` instead of the command line:
+
+```ini
+CONNECTION_MODE = parallel
+BT_ADDRESSES = 70:3e:97:08:00:62,a4:c1:37:40:89:5e
+BT_POLL_INTERVAL = 30
+```
+
+Then simply run:
+
+```sh
+./dbus-btbattery.py
+```
+
+NOTES: This driver is far from complete, so some things will
+probably be broken. Also only JBD BMS is currently supported.

--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -5,10 +5,7 @@ from dbus.mainloop.glib import DBusGMainLoop
 from threading import Thread
 import sys
 
-if sys.version_info.major == 2:
-	import gobject
-else:
-	from gi.repository import GLib as gobject
+from gi.repository import GLib as gobject
 
 from dbushelper import DbusHelper
 from utils import logger
@@ -73,8 +70,6 @@ def main():
 		logger.info("Single battery mode")
 
 	DBusGMainLoop(set_as_default=True)
-	if sys.version_info.major == 2:
-		gobject.threads_init()
 	mainloop = gobject.MainLoop()
 
 	for helper in helpers:

--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from typing import Union
 
-from time import sleep
 from dbus.mainloop.glib import DBusGMainLoop
 from threading import Thread
 import sys
@@ -12,74 +10,86 @@ if sys.version_info.major == 2:
 else:
 	from gi.repository import GLib as gobject
 
-# Victron packages
-# from ve_utils import exit_on_error
-
 from dbushelper import DbusHelper
 from utils import logger
 import utils
-from battery import Battery
 from jbdbt import JbdBt
-from virtual import Virtual
-
+import jbdbt
+from serial import SeriesBattery
+from parallel import ParallelBattery
+from dbus_btbattery_cli import parse_args
 
 
 logger.info("Starting dbus-btbattery")
 
 
 def main():
-	def poll_battery(loop):
-		# Run in separate thread. Pass in the mainloop so the thread can kill us if there is an exception.
-		poller = Thread(target=lambda: helper.publish_battery(loop))
-		# Thread will die with us if deamon
-		poller.daemon = True
-		poller.start()
-		return True
-
-
-	def get_btaddr() -> str:
-		# Get the bluetooth address we need to use from the argument
-		if len(sys.argv) > 1:
-			return sys.argv[1:]
-		else:
-			return False
-
-
 	logger.info(
 		"dbus-btbattery v" + str(utils.DRIVER_VERSION) + utils.DRIVER_SUBVERSION
 	)
 
-	btaddr = get_btaddr()
-	if len(btaddr) == 2:
-		battery: Battery = Virtual( JbdBt(btaddr[0]), JbdBt(btaddr[1]) )
-	elif len(btaddr) == 3:
-		battery: Battery = Virtual( JbdBt(btaddr[0]), JbdBt(btaddr[1]), JbdBt(btaddr[2]) )
-	elif len(btaddr) == 4:
-		battery: Battery = Virtual( JbdBt(btaddr[0]), JbdBt(btaddr[1]), JbdBt(btaddr[2]), JbdBt(btaddr[3]) )
-	else:
-		battery: Battery = JbdBt(btaddr[0])
+	args = parse_args()
 
-	if battery is None:
-		logger.error("ERROR >>> No battery connection at " + str(btaddr))
+	if not args.addresses:
+		logger.error("ERROR >>> No Bluetooth addresses provided")
 		sys.exit(1)
 
-	battery.log_settings()
+	# Apply timing overrides to utils module
+	utils.BT_POLL_INTERVAL = args.bt_poll_interval
+	utils.BT_WATCHDOG_TIMER = args.bt_watchdog_timer
+	utils.DBUS_POLL_INTERVAL = args.dbus_poll_interval
 
-	# Have a mainloop, so we can send/receive asynchronous calls to and from dbus
+	# Apply timing overrides - must set on both utils and jbdbt modules
+	# because jbdbt uses 'from utils import *' (copies at import time)
+	jbdbt.BT_POLL_INTERVAL = args.bt_poll_interval
+	jbdbt.BT_WATCHDOG_TIMER = args.bt_watchdog_timer
+
+	# Create JbdBt instances
+	batteries = [JbdBt(addr) for addr in args.addresses]
+
+	helpers = []
+
+	if args.mode == 'parallel':
+		# Register aggregate first to get lowest instance number
+		aggregate = ParallelBattery(batteries)
+		aggregate.log_settings()
+		helpers.append(DbusHelper(aggregate))
+		# Then register individual batteries
+		for batt in batteries:
+			batt.log_settings()
+			helpers.append(DbusHelper(batt))
+		logger.info(f"Parallel mode: {len(batteries)} individual + 1 aggregate = {len(helpers)} D-Bus services")
+
+	elif args.mode == 'series':
+		aggregate = SeriesBattery(batteries)
+		aggregate.log_settings()
+		helpers.append(DbusHelper(aggregate))
+		logger.info(f"Series mode: {len(batteries)} batteries combined into 1 D-Bus service")
+
+	else:
+		batt = batteries[0]
+		batt.log_settings()
+		helpers.append(DbusHelper(batt))
+		logger.info("Single battery mode")
+
 	DBusGMainLoop(set_as_default=True)
 	if sys.version_info.major == 2:
 		gobject.threads_init()
 	mainloop = gobject.MainLoop()
 
-	# Get the initial values for the battery used by setup_vedbus
-	helper = DbusHelper(battery)
+	for helper in helpers:
+		if not helper.setup_vedbus():
+			logger.error("ERROR >>> Problem setting up vedbus for " + str(helper.battery.port))
+			sys.exit(1)
 
-	if not helper.setup_vedbus():
-		logger.error("ERROR >>> Problem with battery " + str(btaddr))
-		sys.exit(1)
+	def poll_all_batteries(loop):
+		for helper in helpers:
+			poller = Thread(target=lambda h=helper: h.publish_battery(loop))
+			poller.daemon = True
+			poller.start()
+		return True
 
-	# Poll the battery at INTERVAL and run the main loop
-	gobject.timeout_add(battery.poll_interval, lambda: poll_battery(mainloop))
+	gobject.timeout_add(args.dbus_poll_interval, lambda: poll_all_batteries(mainloop))
 	try:
 		mainloop.run()
 	except KeyboardInterrupt:

--- a/dbus_btbattery_cli.py
+++ b/dbus_btbattery_cli.py
@@ -1,0 +1,50 @@
+import argparse
+import utils
+
+
+def parse_args():
+	parser = argparse.ArgumentParser(
+		description='dbus-btbattery: Bluetooth BMS driver for VenusOS'
+	)
+
+	mode_group = parser.add_mutually_exclusive_group()
+	mode_group.add_argument('--parallel', action='store_true',
+							help='Parallel battery mode')
+	mode_group.add_argument('--series', action='store_true',
+							help='Series battery mode')
+
+	parser.add_argument('addresses', nargs='*', default=[],
+						help='Bluetooth MAC addresses')
+
+	parser.add_argument('--bt-poll-interval', type=int, default=None,
+						help='BLE poll interval in seconds')
+	parser.add_argument('--bt-watchdog-timer', type=int, default=None,
+						help='BT watchdog timer in seconds, 0 to disable')
+	parser.add_argument('--dbus-poll-interval', type=int, default=None,
+						help='D-Bus publish interval in milliseconds')
+
+	args = parser.parse_args()
+
+	# Resolve addresses: CLI args override config.ini
+	if not args.addresses and utils.BT_ADDRESSES:
+		args.addresses = utils.BT_ADDRESSES
+
+	# Resolve mode
+	if args.parallel:
+		args.mode = 'parallel'
+	elif args.series:
+		args.mode = 'series'
+	elif len(args.addresses) > 1:
+		args.mode = 'series'  # legacy backwards compat
+	else:
+		args.mode = utils.CONNECTION_MODE if utils.CONNECTION_MODE != 'single' else 'single'
+
+	# Resolve timing: CLI overrides config.ini
+	if args.bt_poll_interval is None:
+		args.bt_poll_interval = utils.BT_POLL_INTERVAL
+	if args.bt_watchdog_timer is None:
+		args.bt_watchdog_timer = utils.BT_WATCHDOG_TIMER
+	if args.dbus_poll_interval is None:
+		args.dbus_poll_interval = utils.DBUS_POLL_INTERVAL
+
+	return args

--- a/dbushelper.py
+++ b/dbushelper.py
@@ -37,6 +37,7 @@ class DbusHelper:
             "com.victronenergy.battery."
             + self.battery.port[self.battery.port.rfind("/") + 1 :],
             get_bus(),
+            register=False,
         )
 
     def setup_instance(self):
@@ -303,6 +304,9 @@ class DbusHelper:
         logger.info(f"publish config values = {PUBLISH_CONFIG_VALUES}")
         if PUBLISH_CONFIG_VALUES == 1:
             publish_config_variables(self._dbusservice)
+
+        # Register on D-Bus after all paths are added (avoids race condition)
+        self._dbusservice.register()
 
         return True
 

--- a/default_config.ini
+++ b/default_config.ini
@@ -135,4 +135,21 @@ LIPRO_CELL_COUNT = 15
 
 PUBLISH_CONFIG_VALUES = 1
 
-BMS_TYPE = 
+BMS_TYPE =
+
+; -------- Connection settings ---------
+; Connection mode: single, series, parallel
+CONNECTION_MODE = single
+
+; Bluetooth addresses (comma-separated for multi-battery)
+; Example: BT_ADDRESSES = 70:3e:97:08:00:62,a4:c1:37:40:89:5e
+BT_ADDRESSES =
+
+; Bluetooth polling interval in seconds (how often BMS is queried over BLE)
+BT_POLL_INTERVAL = 30
+
+; Watchdog timer in seconds (0 to disable, must be >> BT_POLL_INTERVAL)
+BT_WATCHDOG_TIMER = 300
+
+; D-Bus publish interval in milliseconds (how often cached data is pushed to D-Bus)
+DBUS_POLL_INTERVAL = 5000

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -1,13 +1,21 @@
-from bluepy.btle import Peripheral, DefaultDelegate, BTLEException, BTLEDisconnectError
-from threading import Thread, Lock
+import asyncio
+import threading
+from bleak import BleakClient, BleakError
+from threading import Lock
 from battery import Protection, Battery, Cell
 from utils import *
 from struct import *
-import sys
 import time
 import binascii
 import os
 
+# JBD BMS standard GATT UUIDs
+BLE_TX_UUID = "0000ff02-0000-1000-8000-00805f9b34fb"  # Write commands
+BLE_RX_UUID = "0000ff01-0000-1000-8000-00805f9b34fb"  # Receive notifications
+
+# JBD BMS command bytes
+CMD_GENERAL_INFO = b'\xdd\xa5\x03\x00\xff\xfd\x77'
+CMD_CELL_VOLTAGES = b'\xdd\xa5\x04\x00\xff\xfc\x77'
 
 
 class JbdProtection(Protection):
@@ -51,11 +59,8 @@ class JbdProtection(Protection):
 
 
 
-class JbdBtDev(DefaultDelegate, Thread):
+class BleakJbdDev:
 	def __init__(self, address):
-		DefaultDelegate.__init__(self)
-		Thread.__init__(self)
-
 		self.cellDataCallback = None
 		self.cellData = None
 		self.cellDataTotalLen = 0
@@ -69,11 +74,9 @@ class JbdBtDev(DefaultDelegate, Thread):
 
 		self.address = address
 		self.interval = BT_POLL_INTERVAL
-
-		# Bluepy stuff
-		self.bt = Peripheral()
-		self.bt.setDelegate(self)
-
+		self.running = False
+		self._loop = None
+		self._thread = None
 
 	def reset(self):
 		self.last_state = "0000"
@@ -82,49 +85,45 @@ class JbdBtDev(DefaultDelegate, Thread):
 		self.generalDataTotalLen = 0
 		self.generalDataRemainingLen = 0
 
-
-	def run(self):
-		self.running = True
-		timer = 0
-		connected = False
-		while self.running:
-			if not connected:
-				try:
-					logger.info('Connecting ' + self.address)
-					self.bt.connect(self.address, addrType="public")
-					logger.info('Connected ' + self.address)
-					connected = True
-					self.reset()
-				except BTLEException as ex:
-					logger.info('Connection failed: ' + str(ex))
-					time.sleep(3)
-					continue
-
-			try:
-				if self.bt.waitForNotifications(2):
-					continue
-
-				if (time.monotonic() - timer) > self.interval:
-					timer = time.monotonic()
-					result = self.bt.writeCharacteristic(0x15, b'\xdd\xa5\x03\x00\xff\xfd\x77', True)	# write x03 (general info)
-					#time.sleep(1) # Need time between writes?
-					while self.bt.waitForNotifications(1):
-						continue
-					result = self.bt.writeCharacteristic(0x15, b'\xdd\xa5\x04\x00\xff\xfc\x77', True)	# write x04 (cell voltages)
-
-
-			except BTLEDisconnectError:
-				logger.info('Disconnected')
-				connected = False
-				continue
-
-
 	def connect(self):
-		self.daemon=True
-		self.start()
+		self.running = True
+		self._loop = asyncio.new_event_loop()
+		self._thread = threading.Thread(target=self._run_loop, daemon=True)
+		self._thread.start()
+
+	def _run_loop(self):
+		asyncio.set_event_loop(self._loop)
+		self._loop.run_until_complete(self._ble_main_loop())
+
+	async def _ble_main_loop(self):
+		while self.running:
+			try:
+				logger.info('Connecting ' + self.address)
+				async with BleakClient(self.address) as client:
+					logger.info('Connected ' + self.address)
+					self.reset()
+
+					await client.start_notify(BLE_RX_UUID, self._notification_handler)
+
+					while self.running and client.is_connected:
+						await client.write_gatt_char(BLE_TX_UUID, CMD_GENERAL_INFO, response=True)
+						await asyncio.sleep(0.5)
+						await client.write_gatt_char(BLE_TX_UUID, CMD_CELL_VOLTAGES, response=True)
+						await asyncio.sleep(self.interval)
+
+			except BleakError as ex:
+				logger.info('Connection failed: ' + str(ex))
+			except Exception as ex:
+				logger.info('BLE error: ' + str(ex))
+
+			if self.running:
+				logger.info('Disconnected')
+				await asyncio.sleep(3)
 
 	def stop(self):
 		self.running = False
+		if self._loop and self._loop.is_running():
+			self._loop.call_soon_threadsafe(self._loop.stop)
 
 	def addCellDataCallback(self, func):
 		self.cellDataCallback = func
@@ -132,49 +131,42 @@ class JbdBtDev(DefaultDelegate, Thread):
 	def addGeneralDataCallback(self, func):
 		self.generalDataCallback = func
 
-	def handleNotification(self, cHandle, data):
+	def _notification_handler(self, sender, data):
 		if data is None:
 			logger.info("data is None")
 			return
 
 		hex_data = binascii.hexlify(data)
-		hex_string = hex_data.decode('utf-8')		
-		#logger.info("new Hex_String(" +str(len(data))+"): " + str(hex_string))
+		hex_string = hex_data.decode('utf-8')
 
-
-		HEADER_LEN = 4 #[Start Code][Command][Status][Length]
-		FOOTER_LEN = 3 #[16bit Checksum][Stop Code]
+		HEADER_LEN = 4  # [Start Code][Command][Status][Length]
+		FOOTER_LEN = 3  # [16bit Checksum][Stop Code]
 
 		# Route incoming BMS data
 
 		# Cell Data
 		if hex_string.find('dd04') != -1:
 			self.last_state = "dd04"
-			# Because of small MTU size, the BMS data may not be transmitted in a single packet.
-			# We use the 4th byte defined as "data len" in the BMS protocol to calculate the remaining bytes
-			# that will be transmitted in the second packet
 			self.cellDataTotalLen = data[3] + HEADER_LEN + FOOTER_LEN
 			self.cellDataRemainingLen = self.cellDataTotalLen - len(data)
 			logger.info("cellDataTotalLen: " + str(int(self.cellDataTotalLen)))
-			#logger.info("cellDataRemainingLen: " + str(int(self.cellDataRemainingLen)))
 			self.cellData = data
-		elif self.last_state == "dd04" and hex_string.find('dd04') == -1 and hex_string.find('dd03') == -1: 
+		elif self.last_state == "dd04" and hex_string.find('dd04') == -1 and hex_string.find('dd03') == -1:
 			self.cellData = self.cellData + data
-				
+
 		# General Data
 		elif hex_string.find('dd03') != -1:
 			self.last_state = "dd03"
 			self.generalDataTotalLen = data[3] + HEADER_LEN + FOOTER_LEN
 			self.generalDataRemainingLen = self.generalDataTotalLen - len(data)
 			logger.info("generalDataTotalLen: " + str(int(self.generalDataTotalLen)))
-			#logger.info("generalDataRemainingLen: " + str(int(self.generalDataRemainingLen)))
 			self.generalData = data
-		elif self.last_state == "dd03" and hex_string.find('dd04') == -1 and hex_string.find('dd03') == -1: 
-			self.generalData = self.generalData + data			
+		elif self.last_state == "dd03" and hex_string.find('dd04') == -1 and hex_string.find('dd03') == -1:
+			self.generalData = self.generalData + data
 
 		if self.last_state == "dd04" and self.cellData and len(self.cellData) == self.cellDataTotalLen:
 			self.cellDataCallback(self.cellData)
-			logger.info("cellData(" + str(len(self.cellData))+ "): " + str(binascii.hexlify(self.cellData).decode('utf-8')))
+			logger.info("cellData(" + str(len(self.cellData)) + "): " + str(binascii.hexlify(self.cellData).decode('utf-8')))
 			self.last_state = "0000"
 			self.cellData = None
 
@@ -191,10 +183,6 @@ class JbdBt(Battery):
 		self.protection = JbdProtection()
 		self.type = "JBD BT"
 
-		# Bluepy stuff
-		self.bt = Peripheral()
-		self.bt.setDelegate(self)
-
 		self.mutex = Lock()
 		self.generalData = None
 		self.generalDataTS = time.monotonic()
@@ -205,7 +193,7 @@ class JbdBt(Battery):
 		self.port = "/bt" + address.replace(":", "")
 		self.interval = BT_POLL_INTERVAL
 
-		dev = JbdBtDev(self.address)
+		dev = BleakJbdDev(self.address)
 		dev.addCellDataCallback(self.cellDataCB)
 		dev.addGeneralDataCallback(self.generalDataCB)
 		dev.connect()

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -3,15 +3,11 @@ from threading import Thread, Lock
 from battery import Protection, Battery, Cell
 from utils import *
 from struct import *
-import argparse
 import sys
 import time
 import binascii
-import atexit
 import os
 
-# 0 disabled, or set the number of seconds to detect BT hang, and reboot.
-BT_WATCHDOG_TIMER=300
 
 
 class JbdProtection(Protection):
@@ -37,19 +33,19 @@ class JbdProtection(Protection):
 
 	def set_short(self, value):
 		self.short = value
-		self.set_cell_imbalance(
+		self.internal_failure = (
 			2 if self.short or self.IC_inspection or self.software_lock else 0
 		)
 
 	def set_ic_inspection(self, value):
 		self.IC_inspection = value
-		self.set_cell_imbalance(
+		self.internal_failure = (
 			2 if self.short or self.IC_inspection or self.software_lock else 0
 		)
 
 	def set_software_lock(self, value):
 		self.software_lock = value
-		self.set_cell_imbalance(
+		self.internal_failure = (
 			2 if self.short or self.IC_inspection or self.software_lock else 0
 		)
 
@@ -72,7 +68,7 @@ class JbdBtDev(DefaultDelegate, Thread):
 		self.generalDataRemainingLen = 0
 
 		self.address = address
-		self.interval = 5
+		self.interval = BT_POLL_INTERVAL
 
 		# Bluepy stuff
 		self.bt = Peripheral()
@@ -176,16 +172,16 @@ class JbdBtDev(DefaultDelegate, Thread):
 		elif self.last_state == "dd03" and hex_string.find('dd04') == -1 and hex_string.find('dd03') == -1: 
 			self.generalData = self.generalData + data			
 
-		if self.last_state == "dd04" and self.cellData and len(self.cellData) == self.cellDataTotalLen:			
+		if self.last_state == "dd04" and self.cellData and len(self.cellData) == self.cellDataTotalLen:
 			self.cellDataCallback(self.cellData)
 			logger.info("cellData(" + str(len(self.cellData))+ "): " + str(binascii.hexlify(self.cellData).decode('utf-8')))
-			self.last_state == "0000"
+			self.last_state = "0000"
 			self.cellData = None
 
-		if self.last_state == "dd03" and self.generalData and len(self.generalData) == self.generalDataTotalLen:			
+		if self.last_state == "dd03" and self.generalData and len(self.generalData) == self.generalDataTotalLen:
 			self.generalDataCallback(self.generalData)
 			logger.info("generalData(" + str(len(self.generalData)) + "): " + str(binascii.hexlify(self.generalData).decode('utf-8')))
-			self.last_state == "0000"
+			self.last_state = "0000"
 			self.generalData = None
 
 class JbdBt(Battery):
@@ -207,7 +203,7 @@ class JbdBt(Battery):
 
 		self.address = address
 		self.port = "/bt" + address.replace(":", "")
-		self.interval = 5
+		self.interval = BT_POLL_INTERVAL
 
 		dev = JbdBtDev(self.address)
 		dev.addCellDataCallback(self.cellDataCB)
@@ -255,11 +251,11 @@ class JbdBt(Battery):
 		)
 
 		# extra protection flags for LltJbd
-		self.protection.set_voltage_low_cell = is_bit_set(tmp[11])
-		self.protection.set_voltage_high_cell = is_bit_set(tmp[12])
-		self.protection.set_software_lock = is_bit_set(tmp[0])
-		self.protection.set_IC_inspection = is_bit_set(tmp[1])
-		self.protection.set_short = is_bit_set(tmp[2])
+		self.protection.set_voltage_low_cell(is_bit_set(tmp[11]))
+		self.protection.set_voltage_high_cell(is_bit_set(tmp[12]))
+		self.protection.set_software_lock(is_bit_set(tmp[0]))
+		self.protection.set_ic_inspection(is_bit_set(tmp[1]))
+		self.protection.set_short(is_bit_set(tmp[2]))
 
 	def to_cell_bits(self, byte_data, byte_data_high):
 		# clear the list
@@ -349,7 +345,7 @@ class JbdBt(Battery):
 				cell_volts = unpack_from(">H", cell_data, c * 2)
 				if len(cell_volts) != 0:
 					self.cells[c].voltage = cell_volts[0] / 1000
-			except struct.error:
+			except error:
 				self.cells[c].voltage = 0
 
 		return True

--- a/parallel.py
+++ b/parallel.py
@@ -1,0 +1,154 @@
+from battery import Protection, Battery, Cell
+from utils import *
+
+
+_PROTECTION_FIELDS = [
+	"voltage_high",
+	"voltage_low",
+	"voltage_cell_low",
+	"soc_low",
+	"current_over",
+	"current_under",
+	"cell_imbalance",
+	"internal_failure",
+	"temp_high_charge",
+	"temp_low_charge",
+	"temp_high_discharge",
+	"temp_low_discharge",
+]
+
+
+class ParallelBattery(Battery):
+	def __init__(self, batteries=None):
+		Battery.__init__(self, 0, 0, 0)
+
+		self.type = "Parallel"
+		self.port = "/parallel"
+
+		self.batts = list(batteries) if batteries else []
+
+
+	def test_connection(self):
+		return False
+
+
+	def get_settings(self):
+		self.voltage = 0
+		self.current = 0
+		self.cycles = 0
+		self.soc = 0
+		self.cell_count = 0
+		self.capacity = 0
+		self.capacity_remain = 0
+		self.charge_fet = True
+		self.discharge_fet = True
+		self.temp1 = None
+		self.temp2 = None
+
+		result = False
+		success_count = 0
+
+		for b in self.batts:
+			result = b.get_settings()
+			if result:
+				success_count += 1
+
+				# Average voltage
+				self.voltage += b.voltage
+
+				# Cell count: same as a single battery (parallel doesn't add cells)
+				if success_count == 1:
+					self.cell_count = b.cell_count
+
+				# Sum current
+				self.current += b.current
+
+				# Sum capacity
+				self.capacity += b.capacity
+
+				# Sum capacity_remain
+				self.capacity_remain += b.capacity_remain
+
+				# Average SOC
+				self.soc += b.soc
+
+				# Use highest cycle count
+				if b.cycles > self.cycles:
+					self.cycles = b.cycles
+
+				# Max temp1
+				if b.temp1 is not None:
+					if self.temp1 is None or b.temp1 > self.temp1:
+						self.temp1 = b.temp1
+
+				# Max temp2
+				if b.temp2 is not None:
+					if self.temp2 is None or b.temp2 > self.temp2:
+						self.temp2 = b.temp2
+
+				# AND FET states
+				self.charge_fet &= b.charge_fet
+				self.discharge_fet &= b.discharge_fet
+
+		if success_count > 0:
+			# Finalize averages
+			self.voltage /= success_count
+			self.soc /= success_count
+
+			# Use temp_sensors from first battery
+			self.temp_sensors = self.batts[0].temp_sensors
+
+		self.max_battery_voltage = MAX_CELL_VOLTAGE * self.cell_count
+		self.min_battery_voltage = MIN_CELL_VOLTAGE * self.cell_count
+
+		# Current limits scale with number of batteries
+		self.max_battery_charge_current = MAX_BATTERY_CHARGE_CURRENT * success_count
+		self.max_battery_discharge_current = MAX_BATTERY_DISCHARGE_CURRENT * success_count
+
+		return success_count > 0
+
+
+	def _aggregate_protection(self):
+		self.protection = Protection()
+		for field in _PROTECTION_FIELDS:
+			worst = None
+			for b in self.batts:
+				if not hasattr(b, "protection") or b.protection is None:
+					continue
+				val = getattr(b.protection, field, None)
+				if val is None:
+					continue
+				if worst is None or val > worst:
+					worst = val
+			setattr(self.protection, field, worst)
+
+
+	def refresh_data(self):
+		# Refresh each sub-battery first
+		refresh_results = [b.refresh_data() for b in self.batts]
+		any_refreshed = any(refresh_results)
+
+		# Then aggregate the now-fresh data
+		result = self.get_settings()
+
+		# Build cells with min voltage per position
+		self.cells = []
+		if self.cell_count and self.cell_count > 0:
+			for i in range(self.cell_count):
+				min_voltage = None
+				for b in self.batts:
+					if i < len(b.cells) and b.cells[i].voltage is not None:
+						if min_voltage is None or b.cells[i].voltage < min_voltage:
+							min_voltage = b.cells[i].voltage
+				c = Cell(False)
+				c.voltage = min_voltage
+				self.cells.append(c)
+
+		self._aggregate_protection()
+
+		return result and any_refreshed
+
+
+	def log_settings(self):
+		self.get_settings()
+		Battery.log_settings(self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+bleak>=0.21.0
+dbus-python>=1.3.2
+PyGObject>=3.42.0

--- a/scan.py
+++ b/scan.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python3
-from bluepy.btle import Scanner, DefaultDelegate
+import asyncio
+from bleak import BleakScanner
 
-class ScanDelegate(DefaultDelegate):
-	def __init__(self):
-		DefaultDelegate.__init__(self)
 
-	def handleDiscovery(self, dev, isNewDev, isNewData):
-		if isNewDev:
-			print( "Discovered device ", dev.addr)
-		elif isNewData:
-			print( "Received new data from ", dev.addr)
+async def main():
+    print("Scanning for 10 seconds...")
+    devices = await BleakScanner.discover(timeout=10.0)
+    for dev in sorted(devices, key=lambda d: d.rssi, reverse=True):
+        print(f"Device {dev.address}, RSSI={dev.rssi} dB, Name={dev.name or '(unknown)'}")
 
-scanner = Scanner().withDelegate(ScanDelegate())
-devices = scanner.scan(10.0)
 
-for dev in devices:
-	print( "Device %s (%s), RSSI=%d dB" % (dev.addr, dev.addrType, dev.rssi) )
-	for (adtype, desc, value) in dev.getScanData():
-		print( "  %s = %s" % (desc, value) )
+asyncio.run(main())

--- a/serial.py
+++ b/serial.py
@@ -1,31 +1,17 @@
-from battery import Protection, Battery, Cell
+from battery import Battery, Cell
 from utils import *
-from struct import *
-import argparse
-import sys
-import time
-import binascii
-import atexit
 
 
 
-class Virtual(Battery):
-	def __init__(self, b1=None, b2=None, b3=None, b4=None):
+class SeriesBattery(Battery):
+	def __init__(self, batts=None):
 		Battery.__init__(self, 0, 0, 0)
 
-		self.type = "Virtual"
+		self.type = "Series"
 		self.port = "/" + self.type
 
-		self.batts = []
-		if b1:
-			self.batts.append(b1)
-		if b2:
-			self.batts.append(b2)
-		if b3:
-			self.batts.append(b3)
-		if b4:
-			self.batts.append(b4)
-		
+		self.batts = list(batts) if batts else []
+
 
 	def test_connection(self):
 		return False
@@ -46,21 +32,21 @@ class Virtual(Battery):
 		result = False
 		# Loop through all batteries
 		for b in self.batts:
-			result = b.get_settings();
+			result = b.get_settings()
 			if result:
 				# Add battery voltages together
 				self.voltage += b.voltage
-			
+
 				# Add cell counts
 				self.cell_count += b.cell_count
 
 				# Add current values, and div by cell count after the loop to get avg
 				self.current += b.current
 
-				# Use the highest cycle count 
+				# Use the highest cycle count
 				if b.cycles > self.cycles:
 					self.cycles = b.cycles
-				
+
 				# Use the lowest capacity value
 				if b.capacity < self.capacity or self.capacity == 0:
 					self.capacity = b.capacity
@@ -73,8 +59,8 @@ class Virtual(Battery):
 				if b.soc < self.soc or self.soc == 0:
 					self.soc = b.soc
 
-				self.charge_fet &= b.charge_fet 
-				self.discharge_fet &= b.discharge_fet 
+				self.charge_fet &= b.charge_fet
+				self.discharge_fet &= b.discharge_fet
 
 
 		self.cells = [None]*self.cell_count
@@ -108,7 +94,7 @@ class Virtual(Battery):
 		result2 = False
 		# Loop through all batteries
 		for b in self.batts:
-			result2 = b.refresh_data();
+			result2 = b.refresh_data()
 			if result2:
 				# Append cells list
 				self.cells += b.cells
@@ -122,41 +108,3 @@ class Virtual(Battery):
 		# Override log_settings() to call get_settings() first
 		self.get_settings()
 		Battery.log_settings(self)
-
-
-
-
-
-# Unit test
-if __name__ == "__main__":
-	from jbdbt import JbdBt
-
-	batt1 = JbdBt( "70:3e:97:08:00:62" )
-	batt2 = JbdBt( "a4:c1:37:40:89:5e" )
-
-	vbatt = Virtual(batt1, batt2)
-
-	vbatt.get_settings()
-
-	print("Cells " + str(vbatt.cell_count) )
-	print("Voltage " + str(vbatt.voltage) )
-
-	while True:
-		vbatt.refresh_data()
-
-		print("Cells " + str(vbatt.cell_count) )
-		print("Voltage " + str(vbatt.voltage) )
-		print("Current " + str(vbatt.current) )
-		print("Charge FET " + str(vbatt.charge_fet) )
-		print("Discharge FET " + str(vbatt.discharge_fet) )
-
-		for c in range(vbatt.cell_count):
-			print( str(vbatt.cells[c].voltage) + "v", end=" " )
-
-		print("")
-
-
-		time.sleep(5)
-
-
-

--- a/service/run
+++ b/service/run
@@ -1,3 +1,8 @@
 #!/bin/sh
 exec 2>&1
-exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62
+# Single battery:
+# exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62
+# Parallel batteries:
+exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py --parallel 70:3e:97:08:00:62 a4:c1:37:40:89:5e a4:c1:37:00:25:91 a4:c1:37:00:25:92
+# Series batteries:
+# exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py --series 70:3e:97:08:00:62 a4:c1:37:40:89:5e

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,71 @@
+"""
+Tests for dbus_btbattery_cli.parse_args().
+
+Run standalone:
+    python3 tests/test_cli.py
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dbus_btbattery_cli import parse_args
+
+
+def run_parse(argv):
+	"""Helper: set sys.argv and call parse_args()."""
+	sys.argv = ['dbus-btbattery.py'] + argv
+	return parse_args()
+
+
+def test_single_address():
+	args = run_parse(['AA:BB:CC:DD:EE:FF'])
+	assert args.addresses == ['AA:BB:CC:DD:EE:FF'], f"Expected one address, got {args.addresses}"
+	assert args.mode == 'single', f"Expected mode='single', got {args.mode!r}"
+	print("PASS test_single_address")
+
+
+def test_parallel_flag():
+	args = run_parse(['--parallel', 'AA:BB:CC:DD:EE:FF', '11:22:33:44:55:66'])
+	assert args.mode == 'parallel', f"Expected mode='parallel', got {args.mode!r}"
+	assert len(args.addresses) == 2, f"Expected 2 addresses, got {args.addresses}"
+	print("PASS test_parallel_flag")
+
+
+def test_series_flag():
+	args = run_parse(['--series', 'AA:BB:CC:DD:EE:FF', '11:22:33:44:55:66'])
+	assert args.mode == 'series', f"Expected mode='series', got {args.mode!r}"
+	assert len(args.addresses) == 2, f"Expected 2 addresses, got {args.addresses}"
+	print("PASS test_series_flag")
+
+
+def test_legacy_multi_address_defaults_to_series():
+	"""Multiple addresses with no mode flag → series (backwards compat)."""
+	args = run_parse(['AA:BB:CC:DD:EE:FF', '11:22:33:44:55:66'])
+	assert args.mode == 'series', f"Expected mode='series' (legacy), got {args.mode!r}"
+	assert len(args.addresses) == 2, f"Expected 2 addresses, got {args.addresses}"
+	print("PASS test_legacy_multi_address_defaults_to_series")
+
+
+def test_timing_cli_overrides():
+	"""CLI timing args override config defaults."""
+	args = run_parse([
+		'AA:BB:CC:DD:EE:FF',
+		'--bt-poll-interval', '10',
+		'--bt-watchdog-timer', '0',
+		'--dbus-poll-interval', '1000',
+	])
+	assert args.bt_poll_interval == 10, f"Expected bt_poll_interval=10, got {args.bt_poll_interval}"
+	assert args.bt_watchdog_timer == 0, f"Expected bt_watchdog_timer=0, got {args.bt_watchdog_timer}"
+	assert args.dbus_poll_interval == 1000, f"Expected dbus_poll_interval=1000, got {args.dbus_poll_interval}"
+	print("PASS test_timing_cli_overrides")
+
+
+if __name__ == '__main__':
+	test_single_address()
+	test_parallel_flag()
+	test_series_flag()
+	test_legacy_multi_address_defaults_to_series()
+	test_timing_cli_overrides()
+	print("\nAll CLI tests passed")

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,266 @@
+"""
+Tests for ParallelBattery (parallel.py).
+
+Run standalone:
+    python tests/test_parallel.py
+"""
+
+import sys
+import os
+
+# Allow imports from the project root when running standalone
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from battery import Cell, Protection
+from tests.test_serial import make_mock_battery
+from parallel import ParallelBattery
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_mock_battery_with_protection(**kwargs):
+	"""Factory that also sets a Protection object on the mock."""
+	b = make_mock_battery(**kwargs)
+	b.protection = Protection()
+	return b
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_voltage_averages():
+	b1 = make_mock_battery_with_protection(voltage=48.0)
+	b2 = make_mock_battery_with_protection(voltage=50.0)
+	b3 = make_mock_battery_with_protection(voltage=46.0)
+	b4 = make_mock_battery_with_protection(voltage=52.0)
+	pb = ParallelBattery([b1, b2, b3, b4])
+	pb.get_settings()
+	expected = (48.0 + 50.0 + 46.0 + 52.0) / 4
+	assert pb.voltage == expected, f"Expected {expected}, got {pb.voltage}"
+
+
+def test_current_sums():
+	b1 = make_mock_battery_with_protection(current=10.0)
+	b2 = make_mock_battery_with_protection(current=12.0)
+	b3 = make_mock_battery_with_protection(current=8.0)
+	b4 = make_mock_battery_with_protection(current=15.0)
+	pb = ParallelBattery([b1, b2, b3, b4])
+	pb.get_settings()
+	expected = 10.0 + 12.0 + 8.0 + 15.0
+	assert pb.current == expected, f"Expected {expected}, got {pb.current}"
+
+
+def test_capacity_sums():
+	b1 = make_mock_battery_with_protection(capacity=100.0)
+	b2 = make_mock_battery_with_protection(capacity=120.0)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	expected = 100.0 + 120.0
+	assert pb.capacity == expected, f"Expected {expected}, got {pb.capacity}"
+
+
+def test_capacity_remain_sums():
+	b1 = make_mock_battery_with_protection(capacity_remain=80.0)
+	b2 = make_mock_battery_with_protection(capacity_remain=90.0)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	expected = 80.0 + 90.0
+	assert pb.capacity_remain == expected, f"Expected {expected}, got {pb.capacity_remain}"
+
+
+def test_soc_averages():
+	b1 = make_mock_battery_with_protection(soc=80.0)
+	b2 = make_mock_battery_with_protection(soc=60.0)
+	b3 = make_mock_battery_with_protection(soc=70.0)
+	b4 = make_mock_battery_with_protection(soc=90.0)
+	pb = ParallelBattery([b1, b2, b3, b4])
+	pb.get_settings()
+	expected = (80.0 + 60.0 + 70.0 + 90.0) / 4
+	assert pb.soc == expected, f"Expected {expected}, got {pb.soc}"
+
+
+def test_cell_count_same_as_single():
+	b1 = make_mock_battery_with_protection(cell_count=16, voltage=48.0)
+	b2 = make_mock_battery_with_protection(cell_count=16, voltage=48.0)
+	b3 = make_mock_battery_with_protection(cell_count=16, voltage=48.0)
+	b4 = make_mock_battery_with_protection(cell_count=16, voltage=48.0)
+	pb = ParallelBattery([b1, b2, b3, b4])
+	pb.get_settings()
+	# Parallel doesn't add cells — same count as one battery
+	assert pb.cell_count == 16, f"Expected 16, got {pb.cell_count}"
+
+
+def test_cycles_uses_max():
+	b1 = make_mock_battery_with_protection(cycles=10)
+	b2 = make_mock_battery_with_protection(cycles=50)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	assert pb.cycles == 50, f"Expected 50, got {pb.cycles}"
+
+
+def test_temp_uses_max():
+	b1 = make_mock_battery_with_protection(temp1=25.0, temp2=26.0)
+	b2 = make_mock_battery_with_protection(temp1=30.0, temp2=22.0)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	assert pb.temp1 == 30.0, f"Expected temp1=30.0, got {pb.temp1}"
+	assert pb.temp2 == 26.0, f"Expected temp2=26.0, got {pb.temp2}"
+
+
+def test_charge_fet_and_false():
+	b1 = make_mock_battery_with_protection(charge_fet=True, discharge_fet=True)
+	b2 = make_mock_battery_with_protection(charge_fet=False, discharge_fet=True)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	assert pb.charge_fet is False, "charge_fet should be AND — one False makes result False"
+	assert pb.discharge_fet is True, "discharge_fet should remain True when all are True"
+
+
+def test_discharge_fet_and_false():
+	b1 = make_mock_battery_with_protection(charge_fet=True, discharge_fet=True)
+	b2 = make_mock_battery_with_protection(charge_fet=True, discharge_fet=False)
+	pb = ParallelBattery([b1, b2])
+	pb.get_settings()
+	assert pb.discharge_fet is False, "discharge_fet should be AND — one False makes result False"
+	assert pb.charge_fet is True, "charge_fet should remain True when all are True"
+
+
+def test_charge_current_sums():
+	"""max_battery_charge_current = per-battery limit * count"""
+	from utils import MAX_BATTERY_CHARGE_CURRENT, MAX_BATTERY_DISCHARGE_CURRENT
+	b1 = make_mock_battery_with_protection()
+	b2 = make_mock_battery_with_protection()
+	b3 = make_mock_battery_with_protection()
+	pb = ParallelBattery([b1, b2, b3])
+	pb.get_settings()
+	expected_charge = MAX_BATTERY_CHARGE_CURRENT * 3
+	expected_discharge = MAX_BATTERY_DISCHARGE_CURRENT * 3
+	assert pb.max_battery_charge_current == expected_charge, \
+		f"Expected {expected_charge}, got {pb.max_battery_charge_current}"
+	assert pb.max_battery_discharge_current == expected_discharge, \
+		f"Expected {expected_discharge}, got {pb.max_battery_discharge_current}"
+
+
+def test_cells_use_min_voltage_per_position():
+	"""Min voltage per cell position across all batteries."""
+	# Battery 1: cells at 3.3, 3.4, 3.5, 3.6
+	cells_a = []
+	for v in [3.3, 3.4, 3.5, 3.6]:
+		c = Cell(False)
+		c.voltage = v
+		cells_a.append(c)
+
+	# Battery 2: cells at 3.5, 3.2, 3.6, 3.4
+	cells_b = []
+	for v in [3.5, 3.2, 3.6, 3.4]:
+		c = Cell(False)
+		c.voltage = v
+		cells_b.append(c)
+
+	b1 = make_mock_battery_with_protection(cell_count=4, cells=cells_a, voltage=13.8)
+	b2 = make_mock_battery_with_protection(cell_count=4, cells=cells_b, voltage=13.7)
+
+	pb = ParallelBattery([b1, b2])
+	pb.refresh_data()
+
+	# Min per position: [min(3.3,3.5), min(3.4,3.2), min(3.5,3.6), min(3.6,3.4)]
+	expected = [3.3, 3.2, 3.5, 3.4]
+	assert len(pb.cells) == 4, f"Expected 4 cells, got {len(pb.cells)}"
+	for i, exp_v in enumerate(expected):
+		assert pb.cells[i].voltage == exp_v, \
+			f"Cell {i}: expected {exp_v}, got {pb.cells[i].voltage}"
+
+
+def test_protection_worst_case():
+	"""Highest alarm level per field wins."""
+	b1 = make_mock_battery_with_protection()
+	b2 = make_mock_battery_with_protection()
+
+	# Set different alarm levels
+	b1.protection.voltage_high = 1   # Warning
+	b2.protection.voltage_high = 2   # Alarm — should win
+
+	b1.protection.voltage_low = 2    # Alarm — should win
+	b2.protection.voltage_low = 0
+
+	b1.protection.soc_low = None
+	b2.protection.soc_low = 1       # non-None should win over None
+
+	b1.protection.current_over = 0
+	b2.protection.current_over = 0  # both 0, should stay 0
+
+	pb = ParallelBattery([b1, b2])
+	pb.refresh_data()
+
+	assert pb.protection.voltage_high == 2, \
+		f"Expected voltage_high=2, got {pb.protection.voltage_high}"
+	assert pb.protection.voltage_low == 2, \
+		f"Expected voltage_low=2, got {pb.protection.voltage_low}"
+	assert pb.protection.soc_low == 1, \
+		f"Expected soc_low=1, got {pb.protection.soc_low}"
+	assert pb.protection.current_over == 0, \
+		f"Expected current_over=0, got {pb.protection.current_over}"
+
+
+def test_type_string():
+	pb = ParallelBattery([])
+	assert pb.type == "Parallel", f"Expected 'Parallel', got {pb.type}"
+
+
+def test_constructor_accepts_list():
+	batteries = [make_mock_battery_with_protection() for _ in range(3)]
+	pb = ParallelBattery(batteries)
+	assert len(pb.batts) == 3
+
+
+def test_empty_battery_list():
+	pb = ParallelBattery([])
+	result = pb.get_settings()
+	assert result is False, f"Expected False for empty list, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+	tests = [
+		test_voltage_averages,
+		test_current_sums,
+		test_capacity_sums,
+		test_capacity_remain_sums,
+		test_soc_averages,
+		test_cell_count_same_as_single,
+		test_cycles_uses_max,
+		test_temp_uses_max,
+		test_charge_fet_and_false,
+		test_discharge_fet_and_false,
+		test_charge_current_sums,
+		test_cells_use_min_voltage_per_position,
+		test_protection_worst_case,
+		test_type_string,
+		test_constructor_accepts_list,
+		test_empty_battery_list,
+	]
+
+	passed = 0
+	failed = 0
+	for t in tests:
+		try:
+			t()
+			print(f"  PASS  {t.__name__}")
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {t.__name__}: {e}")
+			failed += 1
+
+	print()
+	if failed == 0:
+		print("All ParallelBattery tests passed")
+		sys.exit(0)
+	else:
+		print(f"{failed} test(s) failed")
+		sys.exit(1)

--- a/tests/test_serial.py
+++ b/tests/test_serial.py
@@ -1,0 +1,226 @@
+"""
+Tests for SeriesBattery (serial.py).
+
+MockBattery and make_mock_battery are importable by other test files (e.g. test_parallel.py).
+
+Run standalone:
+    python tests/test_serial.py
+"""
+
+import sys
+import os
+
+# Allow imports from the project root when running standalone
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from battery import Cell
+from serial import SeriesBattery
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+class MockBattery:
+	"""Simulates a JbdBt without needing BLE."""
+
+	def __init__(
+		self,
+		voltage=48.0,
+		current=10.0,
+		soc=80.0,
+		capacity=100.0,
+		capacity_remain=80.0,
+		cell_count=16,
+		cycles=5,
+		charge_fet=True,
+		discharge_fet=True,
+		temp_sensors=2,
+		temp1=25.0,
+		temp2=26.0,
+		cells=None,
+		production=None,
+	):
+		self.voltage = voltage
+		self.current = current
+		self.soc = soc
+		self.capacity = capacity
+		self.capacity_remain = capacity_remain
+		self.cell_count = cell_count
+		self.cycles = cycles
+		self.charge_fet = charge_fet
+		self.discharge_fet = discharge_fet
+		self.temp_sensors = temp_sensors
+		self.temp1 = temp1
+		self.temp2 = temp2
+		self.production = production
+
+		if cells is not None:
+			self.cells = cells
+		else:
+			self.cells = []
+			for _ in range(cell_count):
+				c = Cell(False)
+				c.voltage = round(voltage / cell_count, 4)
+				self.cells.append(c)
+
+	def get_settings(self):
+		return True
+
+	def refresh_data(self):
+		return True
+
+
+def make_mock_battery(**kwargs):
+	"""Factory with sensible defaults. Pass keyword args to override."""
+	return MockBattery(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_voltage_sums():
+	b1 = make_mock_battery(voltage=48.0)
+	b2 = make_mock_battery(voltage=50.0)
+	sb = SeriesBattery([b1, b2])
+	sb.get_settings()
+	assert sb.voltage == 98.0, f"Expected 98.0, got {sb.voltage}"
+
+
+def test_cell_count_sums():
+	b1 = make_mock_battery(cell_count=8, voltage=24.0)
+	b2 = make_mock_battery(cell_count=16, voltage=48.0)
+	sb = SeriesBattery([b1, b2])
+	sb.get_settings()
+	assert sb.cell_count == 24, f"Expected 24, got {sb.cell_count}"
+
+
+def test_current_averages():
+	b1 = make_mock_battery(current=10.0)
+	b2 = make_mock_battery(current=20.0)
+	sb = SeriesBattery([b1, b2])
+	sb.get_settings()
+	assert sb.current == 15.0, f"Expected 15.0, got {sb.current}"
+
+
+def test_soc_uses_lowest():
+	b1 = make_mock_battery(soc=90.0)
+	b2 = make_mock_battery(soc=70.0)
+	b3 = make_mock_battery(soc=85.0)
+	sb = SeriesBattery([b1, b2, b3])
+	sb.get_settings()
+	assert sb.soc == 70.0, f"Expected 70.0, got {sb.soc}"
+
+
+def test_capacity_uses_lowest():
+	b1 = make_mock_battery(capacity=100.0)
+	b2 = make_mock_battery(capacity=90.0)
+	sb = SeriesBattery([b1, b2])
+	sb.get_settings()
+	assert sb.capacity == 90.0, f"Expected 90.0, got {sb.capacity}"
+
+
+def test_refresh_data_concatenates_cells():
+	cells_a = [Cell(False) for _ in range(4)]
+	cells_b = [Cell(False) for _ in range(8)]
+	for i, c in enumerate(cells_a):
+		c.voltage = 3.3 + i * 0.01
+	for i, c in enumerate(cells_b):
+		c.voltage = 3.2 + i * 0.01
+
+	b1 = make_mock_battery(cell_count=4, cells=cells_a, voltage=13.2)
+	b2 = make_mock_battery(cell_count=8, cells=cells_b, voltage=25.6)
+	sb = SeriesBattery([b1, b2])
+	sb.refresh_data()
+	assert len(sb.cells) == 12, f"Expected 12 cells, got {len(sb.cells)}"
+	assert sb.cells[:4] == cells_a, "First 4 cells should come from b1"
+	assert sb.cells[4:] == cells_b, "Last 8 cells should come from b2"
+
+
+def test_single_battery():
+	b = make_mock_battery(voltage=48.0, current=5.0, soc=60.0, capacity=200.0)
+	sb = SeriesBattery([b])
+	sb.get_settings()
+	assert sb.voltage == 48.0
+	assert sb.current == 5.0
+	assert sb.soc == 60.0
+	assert sb.capacity == 200.0
+
+
+def test_empty_battery_list():
+	sb = SeriesBattery([])
+	result = sb.get_settings()
+	# With no batteries get_settings returns False (result never set to True)
+	assert result is False, f"Expected False for empty list, got {result}"
+	assert sb.voltage == 0
+	assert sb.cell_count == 0
+
+
+def test_charge_fet_and():
+	b1 = make_mock_battery(charge_fet=True, discharge_fet=True)
+	b2 = make_mock_battery(charge_fet=False, discharge_fet=True)
+	sb = SeriesBattery([b1, b2])
+	sb.get_settings()
+	assert sb.charge_fet is False, "charge_fet should be AND of all batteries"
+	assert sb.discharge_fet is True, "discharge_fet should be AND of all batteries"
+
+
+def test_cycles_uses_highest():
+	b1 = make_mock_battery(cycles=10)
+	b2 = make_mock_battery(cycles=50)
+	b3 = make_mock_battery(cycles=30)
+	sb = SeriesBattery([b1, b2, b3])
+	sb.get_settings()
+	assert sb.cycles == 50, f"Expected 50, got {sb.cycles}"
+
+
+def test_type_string():
+	sb = SeriesBattery([])
+	assert sb.type == "Series", f"Expected 'Series', got {sb.type}"
+
+
+def test_constructor_accepts_list():
+	batteries = [make_mock_battery() for _ in range(3)]
+	sb = SeriesBattery(batteries)
+	assert len(sb.batts) == 3
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+	tests = [
+		test_voltage_sums,
+		test_cell_count_sums,
+		test_current_averages,
+		test_soc_uses_lowest,
+		test_capacity_uses_lowest,
+		test_refresh_data_concatenates_cells,
+		test_single_battery,
+		test_empty_battery_list,
+		test_charge_fet_and,
+		test_cycles_uses_highest,
+		test_type_string,
+		test_constructor_accepts_list,
+	]
+
+	passed = 0
+	failed = 0
+	for t in tests:
+		try:
+			t()
+			print(f"  PASS  {t.__name__}")
+			passed += 1
+		except Exception as e:
+			print(f"  FAIL  {t.__name__}: {e}")
+			failed += 1
+
+	print()
+	if failed == 0:
+		print("All SeriesBattery tests passed")
+		sys.exit(0)
+	else:
+		print(f"{failed} test(s) failed")
+		sys.exit(1)

--- a/utils.py
+++ b/utils.py
@@ -221,6 +221,13 @@ PUBLISH_CONFIG_VALUES = int(config["DEFAULT"]["PUBLISH_CONFIG_VALUES"])
 
 BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
 
+# Connection settings
+CONNECTION_MODE = config["DEFAULT"]["CONNECTION_MODE"]
+BT_ADDRESSES = _get_list_from_config("DEFAULT", "BT_ADDRESSES")
+BT_POLL_INTERVAL = int(config["DEFAULT"]["BT_POLL_INTERVAL"])
+BT_WATCHDOG_TIMER = int(config["DEFAULT"]["BT_WATCHDOG_TIMER"])
+DBUS_POLL_INTERVAL = int(config["DEFAULT"]["DBUS_POLL_INTERVAL"])
+
 
 def constrain(val, min_val, max_val):
     if min_val > max_val:


### PR DESCRIPTION
## Summary
- Removes the last remaining `bluepy` import from the codebase
- Rewrites `scan.py` using `bleak` (async, pure Python) to match the rest of the driver
- Sorts discovered devices by RSSI descending for easier readability

Closes #

## Test plan
- [ ] Run `./scan.py` on VenusOS device — should list nearby BLE devices without error
- [ ] Confirm battery MAC addresses appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)